### PR TITLE
chore: fix error handling in build command

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -28,12 +28,28 @@ pub fn build_project(config: Config) -> Result<(), io::Error> {
 
     for entry in directory_iterator {
         let file = try!(entry);
-        let file_type = file.file_type().unwrap();
-        let source_file = format!("{}/{}", pages_path, file.file_name().to_str().unwrap());
-        let file_stem = String::from(file.path().file_stem().unwrap().to_str().unwrap());
+        let file_type = try!(file.file_type());
+
+        let file_name = match file.file_name().to_str() {
+            Some(file_name) => file_name.to_string(),
+            None => continue
+        };
+
+        let source_file = format!("{}/{}", pages_path, file_name);
+
+        let file_stem = match file.path().file_stem() {
+            Some(file_stem) => file_stem.to_string_lossy().into_owned(),
+            None => continue
+        };
+
         let destination_file = format!("{}/{}.html", output_dir, file_stem);
 
-        if file_type.is_file() && file.file_name().to_str().unwrap().contains(".md") {
+        let file_ext = match file.file_name().to_str() {
+            Some(file_ext) => file_ext.to_string(),
+            None => continue
+        };
+
+        if file_type.is_file() && file_ext.contains(".md") {
             try!(page_generator.set_input_file(source_file.as_ref())
                      .set_output_file(destination_file.as_ref())
                      .set_wrap(true)


### PR DESCRIPTION
Make code more verbose in exchange for better error handling. I removed
all uses of `unwrap()` from the code in exchange for more verbose code.

[#126842399]
