### PR TITLE
feat: fill in default config on project create

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,4 +1,5 @@
 use std::io;
+use std::io::Write;
 use std::fs;
 use std::fs::{DirBuilder, File};
 use std::path::Path;
@@ -10,7 +11,9 @@ pub fn new_project(parent_dir: &str) -> Result<(), io::Error> {
 
     try!(DirBuilder::new().recursive(false).create(format!("{}/pages", parent_dir)));
 
-    try!(File::create(format!("{}/_config.yml", parent_dir)));
+    let mut config_file = try!(File::create(format!("{}/_config.yml", parent_dir)));
+
+    try!(config_file.write_all(b"source: pages\noutput: _site\n\n"));
 
     Ok(())
 }

--- a/tests/fixtures/config/default.yml
+++ b/tests/fixtures/config/default.yml
@@ -1,0 +1,3 @@
+source: pages
+output: _site
+

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -9,15 +9,28 @@ use aluminum::config;
 
 #[test]
 fn it_creates_a_new_project() {
+    let config_fixture_path = "tests/fixtures/config/default.yml";
+
     let proj_dir = "tests/tmp/new-project";
     let pages_dir = "tests/tmp/new-project/pages";
     let config_path = "tests/tmp/new-project/_config.yml";
 
     commands::new_project(&proj_dir).expect("New Project");
 
+    let mut expected_config_file_contents = String::new();
+    let mut expected_config_file = File::open(config_fixture_path).expect("Expected Config");
+
+    let mut actual_config_file_contents = String::new();
+    let mut actual_config_file = File::open(config_path).expect("Actual Config");
+
+    expected_config_file.read_to_string(&mut expected_config_file_contents).expect("Read Expected");
+    actual_config_file.read_to_string(&mut actual_config_file_contents).expect("Read Actual"    );
+
     assert!(Path::new(&proj_dir).exists());
     assert!(Path::new(&pages_dir).exists());
     assert!(Path::new(&config_path).exists());
+
+    assert_eq!(expected_config_file_contents, actual_config_file_contents);
 
     remove_dir_all(proj_dir).expect("Clean Up");
 }


### PR DESCRIPTION
Fills in a default config file on project creation. This was missed in
the original story to create a new project.

[#126928787]
