### PR TITLE
[#140290941] move after_success to own script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,19 +27,6 @@ branches:
     - develop
 
 script:
-  - |
-      RUSTFLAGS="$RUSTFLAGS -C link-dead-code" cargo test -j8
+  - cargo test -j8
 
-after_success: >
-  if [[ $TRAVIS_RUST_VERSION = 'stable' ]]; then
-    wget https://github.com/SimonKagstrom/kcov/archive/v33.tar.gz
-    tar xzf v33.tar.gz
-    cd kcov-33
-    mkdir build
-    cd build
-    cmake ..
-    make
-    cd ../..
-    ./kcov-33/build/src/kcov --verify --exclude-pattern=/.cargo target/kcov target/debug/aluminum-* &&
-    ./kcov-33/build/src/kcov --coveralls-id=$TRAVIS_JOB_ID --verify --exclude-pattern=/.cargo,tests/lib.rs,src/main.rs target/kcov target/debug/lib-*
-  fi
+after_success: bash ./ci/check_code_coverage.sh

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,8 +33,7 @@ install:
 build: false
 
 test_script:
-  - cargo build --verbose
-  - cargo test
+  - cargo test -j4
 
 branches:
   only:

--- a/ci/check_code_coverage.sh
+++ b/ci/check_code_coverage.sh
@@ -1,0 +1,18 @@
+if [[ $TRAVIS_RUST_VERSION = 'stable' ]]; then
+    # FIXME: Dirty hack to get kcov working for now...
+    wget https://github.com/SimonKagstrom/kcov/archive/1e13fa40156c6717d1efd1f1c13fee8a94b8eea0.zip
+    unzip 1e13fa40156c6717d1efd1f1c13fee8a94b8eea0.zip
+    mv kcov-1e13fa40156c6717d1efd1f1c13fee8a94b8eea0 kcov-master
+    cd kcov-master
+    mkdir build
+    cd build
+    cmake ..
+    make
+    make install DESTDIR=../tmp
+    cd ../..
+    for file in target/debug/aluminum-*; do
+        ./kcov-master/tmp/usr/local/bin/kcov --exclude-pattern=/.cargo,target/ --verify target/kcov target/debug/aluminum-*
+    done
+
+    ./kcov-master/tmp/usr/local/bin/kcov --coveralls-id=$TRAVIS_JOB_ID --exclude-pattern=/.cargo,target/ --verify target/kcov target/debug/lib-*
+fi


### PR DESCRIPTION
Moves the after_success clause of .travis.yml to a separate
ci/after_success.sh script for easier editing, maintenance, and
portability.