### PR TITLE
[#142914969, #142945679] Fix and upgrade kcov

### DIFF
--- a/ci/check_code_coverage.sh
+++ b/ci/check_code_coverage.sh
@@ -1,22 +1,21 @@
 #@IgnoreInspection BashAddShebang
 if [[ $TRAVIS_RUST_VERSION = 'stable' ]]; then
-    # FIXME: Dirty hack to get kcov working for now...
-    wget https://github.com/SimonKagstrom/kcov/archive/v33.zip
-    unzip v33.zip
-    cd kcov-33
+    wget https://github.com/SimonKagstrom/kcov/archive/master.zip
+    unzip master.zip
+    cd kcov-master
     mkdir build
     cd build
     cmake ..
     make
     make install DESTDIR=../../tmp
     cd ../..
-    rm -rf kcov-33
+    rm -rf kcov-master
 
     mkdir -p target/cov/aluminum
     mkdir -p target/cov/lib
     mkdir -p target/cov/merged
-    tmp/usr/local/bin/kcov --exclude-pattern=/.cargo,/usr/lib,tests/ --verify target/cov/aluminum target/debug/aluminum-*
-    tmp/usr/local/bin/kcov --exclude-pattern=/.cargo,/usr/lib,tests/ --verify target/cov/lib target/debug/lib-*
+    tmp/usr/local/bin/kcov --exclude-pattern=/.cargo,/usr/lib,tests/ --verify target/cov/aluminum target/debug/aluminum-*[^d]
+    tmp/usr/local/bin/kcov --exclude-pattern=/.cargo,/usr/lib,tests/ --verify target/cov/lib target/debug/lib-*[^d]
     tmp/usr/local/bin/kcov --merge target/cov/merged target/cov/aluminum target/cov/lib
 
     bash <(curl -s https://codecov.io/bash) -s target/cov/merged


### PR DESCRIPTION
Fixes codecov and upgrades it to the master branch release. Since the
segafault was fixed, I no longer need to use v33 for stable code
coverage metrics. I can go back to using master.